### PR TITLE
replace deprecated include with import_tasks; alinged minimal Ansible…

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Jason L. Shiffer <jshiffer AT zerotao DOT org>
   description: Ansible Role to install packages
   license: BSD
-  min_ansible_version: 1.2
+  min_ansible_version: 2.4
   platforms:
     - name: Fedora
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
-- include: apt.yml
+- import_tasks: apt.yml
   tags: [packages]
   when: ansible_pkg_mgr == "apt"
 
-- include: yum.yml
+- import_tasks: yum.yml
   tags: [packages]
   when: ansible_pkg_mgr == "yum"
 


### PR DESCRIPTION
Hello @zerotao,

this small PR fixes a deprecation warning in Ansible 2.4 and set's the minimal version to 2.4 too.

Best regards

jardleex